### PR TITLE
feat: add gitleaks action

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,19 @@
+name: gitleaks
+on:
+  push:
+  pull_request:
+  issues:
+  issue_comment:
+
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,10 +10,13 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out git repository
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 1
-      - uses: gitleaks/gitleaks-action@v2
+          fetch-depth: 2
+
+      - name: run gitleaks scan
+        uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out git repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: run gitleaks scan
         uses: gitleaks/gitleaks-action@v2


### PR DESCRIPTION
This issue addresses part of https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/bloom-housing/bloom/5358

This adds a github action which will alert on pushes that contain patterns matching secrets, keys, tokens, etc. If any secrets are found a comment will be added in the PR to rotate it. See results from test secrets below.

<img width="1232" height="709" alt="Screenshot 2025-09-11 at 12 23 07 PM" src="https://github.com/user-attachments/assets/ec331942-f7f1-476f-8765-93d327696679" />


The comments below were to test if it would work on pr comments as well. It looks like for this to be a valid test the action may need to be on the main branch. I will test again after merge.